### PR TITLE
Adds a memory check when generating chunks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,9 @@ pipeline {
         sh '''#! /bin/bash
           export WPS_TEST=1
           export DJANGO_CONFIG_PATH=${PWD}/docker/common/django.properties
-
+    
+          trap "conda env remove -n wps -y;" SIGINT SIGTERM EXIT
+          
           conda env remove -n wps -q -y > /dev/null 2>&1 || exit 1
 
           conda env create -n wps --file docker/common/environment.yml

--- a/compute/compute/settings.py
+++ b/compute/compute/settings.py
@@ -117,6 +117,7 @@ ACTIVE_USER_THRESHOLD = config.get_value('default', 'active.user.threshold', 5, 
 INGRESS_ENABLED = config.get_value('default', 'ingress.enabled', True, bool)
 PROCESS_BLACKLIST = config.get_value('default', 'process.blacklist', [], list)
 CERT_DOWNLOAD_ENABLED = config.get_value('default', 'cert.download.enabled', True, bool)
+WORKER_MEMORY = config.get_value('default', 'worker.memory', 1e9, int)
 
 # Application definition
 EMAIL_HOST = config.get_value('email', 'host', 'localhost')

--- a/compute/wps/backends/cdat.py
+++ b/compute/wps/backends/cdat.py
@@ -192,7 +192,7 @@ class CDAT(backend.Backend):
                 uri, config['var_name'], job_id=job.id).set(**helpers.DEFAULT_QUEUE)
 
             generate_chunks = tasks.generate_chunks.s(
-                uri, config['axis'], job_id=job.id).set(**helpers.DEFAULT_QUEUE)
+                operation, uri, config['axis'], job_id=job.id).set(**helpers.DEFAULT_QUEUE)
 
             analysis[uri] = [check_cache, generate_chunks]
 

--- a/compute/wps/backends/cdat.py
+++ b/compute/wps/backends/cdat.py
@@ -192,7 +192,7 @@ class CDAT(backend.Backend):
                 uri, config['var_name'], job_id=job.id).set(**helpers.DEFAULT_QUEUE)
 
             generate_chunks = tasks.generate_chunks.s(
-                operation, uri, config['axis'], job_id=job.id).set(**helpers.DEFAULT_QUEUE)
+                config['operation'], uri, config['axis'], job_id=job.id).set(**helpers.DEFAULT_QUEUE)
 
             analysis[uri] = [check_cache, generate_chunks]
 

--- a/compute/wps/tasks/preprocess.py
+++ b/compute/wps/tasks/preprocess.py
@@ -3,6 +3,7 @@
 import contextlib
 import hashlib
 import json
+import math
 import os
 
 import cwt
@@ -87,7 +88,8 @@ def generate_chunks(self, attrs, uri, process_axes, job_id):
 
         return attrs
 
-    if process_axes == None:
+    # Determine the axis to generate chunks for, defaults to time axis
+    if process_axes == None or 'time' not in process_axes:
         chunked_axis = 'time'
     else:
         process_axes = set(process_axes)
@@ -102,8 +104,37 @@ def generate_chunks(self, attrs, uri, process_axes, job_id):
 
     chunk_axis = mapped[chunked_axis]
 
-    for begin in xrange(chunk_axis.start, chunk_axis.stop, settings.WPS_PARTITION_SIZE):
-        end = min(begin+settings.WPS_PARTITION_SIZE, chunk_axis.stop)
+    axis_size = dict((x, (y.stop-y.start)/y.step) for x, y in mapped.iteritems())
+
+    chunk_axis_size = dict(x for x in axis_size.items() if x[0] !=
+                           chunked_axis)
+
+    logger.info('Worker memory size %r', settings.WORKER_MEMORY)
+
+    est_total_size = reduce(lambda x, y: x*y, axis_size.values())*4
+
+    logger.info('Estimated size in memory %r', est_total_size)
+
+    est_chunk_size = reduce(lambda x, y: x*y, chunk_axis_size.values())*4
+
+    logger.info('Estimated chunk size in memory %r', est_chunk_size)
+
+    chunks_total = est_total_size/est_chunk_size
+
+    logger.info('Chunks total %r', chunks_total)
+
+    chunks_per_worker = round((settings.WORKER_MEMORY*0.50)/est_chunk_size)
+
+    logger.info('Chunks per worker %r', chunks_per_worker)
+
+    if chunks_per_worker == 0:
+        raise WPSError('Chunk size of %r bytes is too large for workers memory try reducing the size by subsetting', 
+                       est_chunk_size)
+
+    partition_size = int(min(chunks_per_worker, chunks_total))
+
+    for begin in xrange(chunk_axis.start, chunk_axis.stop, partition_size):
+        end = min(begin+partition_size, chunk_axis.stop)
 
         chunks.append(slice(begin, end, chunk_axis.step))
 

--- a/compute/wps/tasks/preprocess.py
+++ b/compute/wps/tasks/preprocess.py
@@ -91,7 +91,7 @@ def generate_chunks(self, attrs, operation, uri, process_axes, job_id):
     # Determine the axis to generate chunks for, defaults to time axis
     if operation.identifier == 'CDAT.average' and len(process_axes) > 1:
         chunked_axis = None
-    elif process_axes == None or 'time' not in process_axes:
+    elif process_axes is None or 'time' not in process_axes:
         chunked_axis = 'time'
     else:
         process_axes = set(process_axes)

--- a/compute/wps/tasks/preprocess.py
+++ b/compute/wps/tasks/preprocess.py
@@ -207,7 +207,7 @@ def check_cache(self, attrs, uri, var_name, job_id):
 
             stop = mapped_axis.stop - orig_axis.start
 
-            new_mapped[key] = slice(start, stop)
+            new_mapped[key] = slice(start, stop, mapped_axis.step)
 
         attrs[uri]['cached'] = {
             'path': entry.local_path,

--- a/compute/wps/tests/test_auth_views.py
+++ b/compute/wps/tests/test_auth_views.py
@@ -224,7 +224,7 @@ class AuthViewsTestCase(test.TestCase):
         self.assertEqual(data['type'], 'myproxyclient')
 
     def test_oauth2_callback_invalid_state(self):
-        response = self.client.get('/auth/callback/', {})
+        response = self.client.get('/auth/callback', {})
 
         self.check_redirect(response, 1)
 
@@ -252,7 +252,7 @@ class AuthViewsTestCase(test.TestCase):
 
         session.save()
 
-        response = self.client.get('/auth/callback/', {})
+        response = self.client.get('/auth/callback', {})
 
         self.check_redirect(response, 1)
 

--- a/compute/wps/tests/test_tasks_preprocess.py
+++ b/compute/wps/tests/test_tasks_preprocess.py
@@ -495,6 +495,8 @@ class PreprocessTestCase(test.TestCase):
             'time': slice(0, 2000),
         }
 
+        self.maxDiff = None
+
         type(mock_entries.return_value).dimensions = mock.PropertyMock(return_value=helpers.encoder(data))
         type(mock_entries.return_value).local_path = mock.PropertyMock(return_value='./file1.nc')
 
@@ -523,9 +525,9 @@ class PreprocessTestCase(test.TestCase):
                 'cached': {
                     'path': './file1.nc',
                     'mapped': {
-                        'lat': slice(80, 180),
-                        'lon': slice(10, 60),
-                        'time': slice(0, 1500),
+                        'lat': slice(80, 180, 1),
+                        'lon': slice(10, 60, 1),
+                        'time': slice(0, 1500, 1),
                     }
                 },
                 'mapped': {


### PR DESCRIPTION
Adds memory check while generating chunks #155.

To run the tests follow [setup](https://github.com/ESGF/esgf-compute-wps/blob/metrics_update/docs/source/testing.md)

`python compute/manage.py test wps.tests.test_tasks_preprocess`