### PR TITLE
Thredds update

### DIFF
--- a/compute/wps/backends/backend.py
+++ b/compute/wps/backends/backend.py
@@ -2,6 +2,7 @@ import logging
 
 import cwt
 from django import db
+from django.conf import settings
 
 from wps import models
 
@@ -38,6 +39,20 @@ class Backend(object):
 
     def __init__(self):
         self.processes = []
+
+    def load_user(self, user_id):
+        try:
+            user = models.User.objects.get(pk=user_id)
+        except models.User.DoesNotExist:
+            raise WPSError('User "{}" does not exist', user_id)
+
+        return user
+
+    def generate_output_path(self, user, filename):
+        job_id = user.job_set.count()
+
+        return '{}/{}/{}/{}.nc'.format(settings.WPS_PUBLIC_PATH, user.id,
+                                       job_id, filename)
 
     def add_process(self, identifier, name, metadata, data_inputs=None, process_outputs=None, abstract=None):
         """ Adds a process/operation to a backend.

--- a/compute/wps/backends/cdat.py
+++ b/compute/wps/backends/cdat.py
@@ -288,6 +288,8 @@ class CDAT(backend.Backend):
                            operation, user_id, job_id, **kwargs):
         op = operation[root]
 
+        user = self.load_user(user_id)
+
         process = models.Process.objects.get(identifier=op.identifier)
 
         logger.info('Executing %r', op)
@@ -344,7 +346,7 @@ class CDAT(backend.Backend):
 
         del kwargs['index']
 
-        output_path = '{}/{}.nc'.format(settings.WPS_PUBLIC_PATH, op_uid)
+        output_path = self.generate_output_path(user, op_uid)
 
         success = tasks.job_succeeded.s(
             variable.values(), output_path, None, var_name, process.id, user_id, job_id=job_id).set(
@@ -381,6 +383,8 @@ class CDAT(backend.Backend):
     def execute_computation(self, root, base_units, variable, domain, 
                             operation, user_id, job_id, **kwargs):
         op = operation[root]
+
+        user = self.load_user(user_id)
 
         logger.info('Executing %r', op)
 
@@ -484,7 +488,7 @@ class CDAT(backend.Backend):
             job_id=job_id).set(
                 **helpers.DEFAULT_QUEUE)
 
-        output_path = '{}/{}.nc'.format(settings.WPS_PUBLIC_PATH, op_uid)
+        output_path = self.generate_output_path(user, op_uid)
 
         process_obj = models.Process.objects.get(identifier=process.IDENTIFIER)
 

--- a/compute/wps/tasks/cdat.py
+++ b/compute/wps/tasks/cdat.py
@@ -125,6 +125,8 @@ def base_retrieve(self, attrs, keys, operation, var_name, base_units, output_pat
 
     start = self.get_now()
 
+    os.makedirs(os.path.dirname(output_path))
+
     with self.open(output_path, 'w') as outfile:
         # Expect the keys to be given in a sortable format
         for key in sorted(keys):

--- a/compute/wps/tasks/cdat.py
+++ b/compute/wps/tasks/cdat.py
@@ -125,7 +125,10 @@ def base_retrieve(self, attrs, keys, operation, var_name, base_units, output_pat
 
     start = self.get_now()
 
-    os.makedirs(os.path.dirname(output_path))
+    try:
+        os.makedirs(os.path.dirname(output_path))
+    except OSError:
+        raise WPSError('Failed to create output directory')
 
     with self.open(output_path, 'w') as outfile:
         # Expect the keys to be given in a sortable format

--- a/compute/wps/tasks/job.py
+++ b/compute/wps/tasks/job.py
@@ -38,15 +38,15 @@ def job_succeeded(self, attrs, variables, output_path, move_path, var_name,
     process = self.load_process(process_id)
 
     if move_path is not None:
+        os.makedirs(os.path.dirname(move_path))
+
         shutil.move(output_path, move_path)
         
-        _, filename = os.path.split(move_path)
+        output_path = move_path
 
-        url = settings.WPS_DAP_URL.format(filename=filename)
-    else:
-        _, filename = os.path.split(output_path)
+    relpath = os.path.relpath(output_path, settings.WPS_PUBLIC_PATH)
 
-        url = settings.WPS_DAP_URL.format(filename=filename)
+    url = settings.WPS_DAP_URL.format(filename=relpath)
 
     output = cwt.Variable(url, var_name)
 

--- a/compute/wps/tasks/job.py
+++ b/compute/wps/tasks/job.py
@@ -10,6 +10,7 @@ from django.conf import settings
 
 from wps import metrics
 from wps import models
+from wps import WPSError
 from wps.tasks import base
 
 logger = get_task_logger('wps.tasks.job')
@@ -38,7 +39,10 @@ def job_succeeded(self, attrs, variables, output_path, move_path, var_name,
     process = self.load_process(process_id)
 
     if move_path is not None:
-        os.makedirs(os.path.dirname(move_path))
+        try:
+            os.makedirs(os.path.dirname(move_path))
+        except OSError:
+            raise WPSError('Failed to create output directory')
 
         shutil.move(output_path, move_path)
         

--- a/compute/wps/tests/test_tasks_cdat.py
+++ b/compute/wps/tests/test_tasks_cdat.py
@@ -281,7 +281,8 @@ class CDATTaskTestCase(test.TestCase):
 
     @mock.patch('wps.tasks.cdat.retrieve_data_cached')
     @mock.patch('os.stat')
-    def test_base_retrieve_cached(self, mock_stat, mock_retrieve):
+    @mock.patch('os.makedirs')
+    def test_base_retrieve_cached(self, mock_make, mock_stat, mock_retrieve):
         type(mock_stat.return_value).st_size = mock.PropertyMock(return_value=1200000)
 
         attrs = {
@@ -311,7 +312,8 @@ class CDATTaskTestCase(test.TestCase):
 
     @mock.patch('wps.tasks.cdat.retrieve_data')
     @mock.patch('os.stat')
-    def test_base_retrieve_regrid(self, mock_stat, mock_retrieve):
+    @mock.patch('os.makedirs')
+    def test_base_retrieve_regrid(self, mock_make, mock_stat, mock_retrieve):
         now = datetime.datetime.now()
 
         type(mock_stat.return_value).st_size = mock.PropertyMock(return_value=1200000)
@@ -347,7 +349,8 @@ class CDATTaskTestCase(test.TestCase):
 
     @mock.patch('wps.tasks.cdat.retrieve_data')
     @mock.patch('os.stat')
-    def test_base_retrieve(self, mock_stat, mock_retrieve):
+    @mock.patch('os.makedirs')
+    def test_base_retrieve(self, mock_make, mock_stat, mock_retrieve):
         type(mock_stat.return_value).st_size = mock.PropertyMock(return_value=1200000)
 
         keys = ['file01.nc', 'file02.nc']


### PR DESCRIPTION
Quick update to fix the paths of output files.

The URL path should be "threddsCWT/public/{user id}/{job number}/{uid}.nc"

This will be used later when we implement protection for user files.