### PR TITLE
fix url typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ESGF Compute WPS
 
 ESGF Compute is a Django application capable of providing compute resources to
-the ESGF data stack. It leverages the 1.0.0 version of the [Web Processing Service](http://www.opengeospatial.org/standards/wps>) (WPS)
+the ESGF data stack. It leverages the 1.0.0 version of the [Web Processing Service](http://www.opengeospatial.org/standards/wps) (WPS)
 standard to process compute requests.
 
 # Contribute


### PR DESCRIPTION
I found a broken link while browsing the docs